### PR TITLE
fix: Merge file functions produce errors

### DIFF
--- a/source/stitch/public/Configuration/Convert-ConfigurationFile.ps1
+++ b/source/stitch/public/Configuration/Convert-ConfigurationFile.ps1
@@ -8,9 +8,9 @@ function Convert-ConfigurationFile {
     param(
         # Specifies a path to one or more configuration files.
         [Parameter(
-        Position = 0,
-        ValueFromPipeline,
-        ValueFromPipelineByPropertyName
+            Position = 0,
+            ValueFromPipeline,
+            ValueFromPipelineByPropertyName
         )]
         [Alias('PSPath')]
         [string[]]$Path
@@ -19,7 +19,6 @@ function Convert-ConfigurationFile {
         Write-Debug "`n$('-' * 80)`n-- Begin $($MyInvocation.MyCommand.Name)`n$('-' * 80)"
     }
     process {
-        Write-Debug "`n$('-' * 80)`n-- Process start $($MyInvocation.MyCommand.Name)`n$('-' * 80)"
         Write-Debug "Getting ready to convert configuration file $Path"
         if (Test-Path $Path) {
             Write-Debug '  - File exists'
@@ -48,7 +47,6 @@ function Convert-ConfigurationFile {
                 }
             }
         }
-        Write-Debug "`n$('-' * 80)`n-- Process end $($MyInvocation.MyCommand.Name)`n$('-' * 80)"
     }
     end {
         Write-Debug "`n$('-' * 80)`n-- End $($MyInvocation.MyCommand.Name)`n$('-' * 80)"

--- a/source/stitch/public/Configuration/Merge-BuildConfiguration.ps1
+++ b/source/stitch/public/Configuration/Merge-BuildConfiguration.ps1
@@ -1,15 +1,6 @@
 function Merge-BuildConfiguration {
     [CmdletBinding()]
     param(
-        # Specifies a path to one or more configuration files
-        [Parameter(
-        Position = 2,
-        ValueFromPipeline,
-        ValueFromPipelineByPropertyName
-        )]
-        [Alias('PSPath')]
-        [string[]]$Path,
-
         # The object to merge the configuration into (by reference)
         [Parameter(
             Mandatory,
@@ -20,21 +11,33 @@ function Merge-BuildConfiguration {
         # The top level key in which to add the given table
         [Parameter(
             Position = 1
-        )]
-        [string]$Key
+            )]
+            [string]$Key,
+
+            # Specifies a path to one or more configuration files
+            [Parameter(
+            Position = 2,
+            ValueFromPipeline,
+            ValueFromPipelineByPropertyName
+            )]
+            [Alias('PSPath')]
+            [string[]]$Path
     )
     begin {
         Write-Debug "`n$('-' * 80)`n-- Begin $($MyInvocation.MyCommand.Name)`n$('-' * 80)"
     }
     process {
-        Write-Debug "`n$('-' * 80)`n-- Process start $($MyInvocation.MyCommand.Name)`n$('-' * 80)"
         foreach ($file in $Path) {
             $options = Convert-ConfigurationFile $Path
+
             if ($null -ne $options) {
-                $Object.Value | Update-Object -UpdateObject $options
+                if ($PSBoundParameters.ContainsKey('Key')) {
+                    $Object.Value.$Key | Update-Object -UpdateObject $options
+                } else {
+                    $Object.Value | Update-Object -UpdateObject $options
+                }
             }
         }
-        Write-Debug "`n$('-' * 80)`n-- Process end $($MyInvocation.MyCommand.Name)`n$('-' * 80)"
     }
     end {
         Write-Debug "`n$('-' * 80)`n-- End $($MyInvocation.MyCommand.Name)`n$('-' * 80)"

--- a/source/stitch/public/Content/Merge-SourceItem.ps1
+++ b/source/stitch/public/Content/Merge-SourceItem.ps1
@@ -195,18 +195,20 @@ function Merge-SourceItem {
                 $statements = $combinedUsingStatements | Where-Object UsingStatementKind -Like $kind
 
                 if ($statements.Count -gt 0) {
-                    Write-Debug "     - $($statements.Count) found"
+                    Write-Debug "     - $($statements.Count) statements found"
                     $added = @()
                     foreach ($statement in $statements) {
                         $s = $statement.Extent.Text
+                        Write-Debug "       - Statement Text: '$s'"
+
                         if ($added -contains $s) {
-                            Write-Debug "       - '$s' already processed"
+                            Write-Debug "         - already processed"
                         } else {
-                            Write-Debug "       - Looking for '$s' in content"
+                            Write-Debug "         - Looking for '$s' in content"
                             # first, remove the line from the original content
-                            if (($content) -match [regex]::Escape($s)) {
+                            if ($content -match "^$([regex]::Escape($s))`$") {
                                 Write-Debug "       - found '$s' in content"
-                                $content = ($content) -replace [regex]::Escape($s), ''
+                                $content = ($content) -replace "^$([regex]::Escape($s))`$", ''
                             }
                             $null = $sb.AppendLine($s)
                             $added += $s


### PR DESCRIPTION
- Merge SourceItem added extra lines in the "using namespace" section. This was because the regex needed to include the entire line.
- Merge Build Configuration did not implement the ability to merge at a specific key.
