### PR TITLE
`before` and `after` modify Jobs array

### DIFF
--- a/source/stitch/BuildScripts/AddTaskFunctions/Add-AfterTask.task.ps1
+++ b/source/stitch/BuildScripts/AddTaskFunctions/Add-AfterTask.task.ps1
@@ -1,59 +1,76 @@
 
-Set-Alias after Add-AfterTask
 function Add-AfterTask {
     <#
-.SYNOPSIS
-    Add tasks to run after another without needing to modify the original task
-.EXAMPLE
-    Package | after Build
+    .SYNOPSIS
+        Add tasks to run after another without needing to modify the original task
+    .EXAMPLE
+        Package | after Build
 
-    This will ensure that the Package task is run after the Build task
+        "Run 'Package' after 'Build'"
+        This will ensure that the Package task is run after the Build task
 
-.EXAMPLE
-    Package | after Clean, Build
-#>
+    .EXAMPLE
+        Package | after Validate
+        Jobs    | after Task
+        Validate.Jobs = @( ..., 'Package')
+    #>
+    [Alias('after')]
+    [CmdletBinding()]
     param(
-        # The primary task that requires the TaskList to be run first
+        # The primary task. Jobs will be added to the end of this Task.
         [Parameter(
             Mandatory,
             Position = 0
-        )][string]$Name,
+        )][string[]]$Task,
 
-        # The task(s) that will be run after the task Name
+        # The job(s) that will be run after the Task
         [Parameter(
             Mandatory,
             Position = 1,
             ValueFromPipeline
-        )][string[]]$TaskList
+        )][string[]]$Jobs
 
     )
     begin {
         Write-Debug "`n$('-' * 80)`n-- Begin $($MyInvocation.MyCommand.Name)`n$('-' * 80)"
+        $allTasks     = ${*}.All.Keys
+        $errorMessage = "Could not add {0} after {1}. '{2}' is not a valid task name"
     }
     process {
-        $allTasks = ${*}.All.Keys
-        $errorMessage = "Could not add {0} after {1}. '{2}' in not a valid task name"
+        if ($null -ne $allTasks) {
+            foreach ($currentTask in $Task) {
+                # Normalize the name of the Task
+                $taskName   = $currentTask | Resolve-TaskName
 
-        if ($allTasks -contains $Name) {
-            Write-Debug "$Name is a valid task"
-            foreach ($item in $TaskList) {
-                    if ($allTasks -contains $item) {
-                        Write-Debug "Adding $item to After list of $Name"
-                        ${*}.All[$item].After += $Name
-                    } else {
-                        throw ($errorMessage -f $item, $Name, $item)
+                if ($allTasks -contains $taskName) {
+                    foreach ($currentJob in $Jobs) {
+                        $jobName = $currentJob | Resolve-TaskName
+
+                        # if The current job is a valid task
+                        if ($allTasks -contains $jobName) {
+                            # if it is not already in the job list for this task
+                            if (${*}.All[$taskName].Jobs -notcontains $currentJob) {
+                                Write-Debug "Adding $currentJob to end of $taskName Jobs"
+                                ${*}.All[$taskName].Jobs.Add($currentJob)
+                            } else {
+                                Write-Verbose "$currentJob already a job of $currentTask"
+                            }
+                        } else {
+                            throw ($errorMessage -f $currentJob, $currentTask, $currentJob)
+                        }
                     }
+                } else {
+                    throw ($errorMessage -f $currentJob, $currentTask, $currentTask)
+                }
+
+                #! If we are in the pipeline, send out the Task name
+                if ($MyInvocation.PipelinePosition -lt $MyInvocation.PipelineLength) {
+                    $currentTask | Write-Output
+                }
             }
-        } else {
-            throw ($errorMessage -f $item, $Name, $Name)
         }
     }
     end {
-        if ($MyInvocation.PipelinePosition -lt $MyInvocation.PipelineLength) {
-            Write-Debug "Sending $Name to pipeline"
-            $Name | Write-Output
-        }
         Write-Debug "`n$('-' * 80)`n-- End $($MyInvocation.MyCommand.Name)`n$('-' * 80)"
     }
-
 }

--- a/source/stitch/BuildScripts/AddTaskFunctions/Add-BeforeTask.task.ps1
+++ b/source/stitch/BuildScripts/AddTaskFunctions/Add-BeforeTask.task.ps1
@@ -1,64 +1,78 @@
 
-Set-Alias before Add-BeforeTask
 function Add-BeforeTask {
     <#
-.SYNOPSIS
-    Add tasks to run before another without needing to modify the original task
-.EXAMPLE
-    Build | before Package
+    .SYNOPSIS
+        Add tasks to run before another without needing to modify the original task
+    .EXAMPLE
+        Build | before Validate
 
-    This will ensure that the build task is run before the package
+        "Run 'Build' before 'Validate'"
+        This will ensure that the Build task is run before the Validate task
 
-.EXAMPLE
-    before Package Clean, Build
-#>
+    .EXAMPLE
+        Build | before Validate
+        Jobs    | before Task
+        Validate.Jobs = @( 'Build' , ... )
+    #>
+    [Alias('before')]
+    [CmdletBinding()]
     param(
-        # The primary task to add the TaskList to the 'Before' array
+        # The primary task. Jobs will be added to the end of this Task.
         [Parameter(
             Mandatory,
             Position = 0
-        )]
-        [string]$Name,
+        )][string[]]$Task,
 
-        # The task(s) that will be run before the task Name
+        # The job(s) that will be run before the Task
         [Parameter(
             Mandatory,
             Position = 1,
             ValueFromPipeline
-        )]
-        [string[]]$TaskList
+        )][string[]]$Jobs
 
     )
     begin {
         Write-Debug "`n$('-' * 80)`n-- Begin $($MyInvocation.MyCommand.Name)`n$('-' * 80)"
+        $allTasks     = ${*}.All.Keys
+        $errorMessage = "Could not add {0} before {1}. '{2}' is not a valid task name"
+        #! Create a new list to replace the Jobs list with before processing
     }
     process {
-        $allTaskNames = ${*}.All.Keys
-        $errorMessage = "Could not add {0} before {1}. '{2}' in not a valid task name"
+        if ($null -ne $allTasks) {
+            foreach ($currentTask in $Task) {
+                # Normalize the name of the Task
+                $taskName   = $currentTask | Resolve-TaskName
+                #! Start with the current list of Jobs
 
-        if ($allTaskNames -contains $Name) {
-            Write-Debug "$Name is a valid task"
-            foreach ($item in $TaskList) {
-                if ($allTaskNames -contains $item) {
-                    Write-Debug "Adding $item to Before list of $Name"
+                if ($allTasks -contains $taskName) {
+                    foreach ($currentJob in $Jobs) {
+                        $jobName = $currentJob | Resolve-TaskName
 
-                    ${*}.All[$item].Before += $Name
+                        # if The current job is a valid task
+                        if ($allTasks -contains $jobName) {
+                            # if it is not already in the job list for this task
+                            if (${*}.All[$taskName].Jobs -notcontains $currentJob) {
+                                Write-Debug "Adding $currentJob to beginning of $taskName Jobs"
+                                ${*}.All[$taskName].Jobs.Insert(0,$currentJob)
+                            } else {
+                                Write-Verbose "$currentJob already a job of $currentTask"
+                            }
+                        } else {
+                            throw ($errorMessage -f $currentJob, $currentTask, $currentJob)
+                        }
+                    }
                 } else {
-                    throw ($errorMessage -f $item, $Name, $item)
+                    throw ($errorMessage -f $currentJob, $currentTask, $currentTask)
+                }
+
+                #! If we are in the pipeline, send out the Task name
+                if ($MyInvocation.PipelinePosition -lt $MyInvocation.PipelineLength) {
+                    $currentTask | Write-Output
                 }
             }
-        } else {
-            throw ($errorMessage -f $item, $Name, $Name)
         }
     }
     end {
-        if ($MyInvocation.PipelinePosition -lt $MyInvocation.PipelineLength) {
-            Write-Debug "Sending $Name to pipeline"
-            $Name | Write-Output
-        }
-
-
         Write-Debug "`n$('-' * 80)`n-- End $($MyInvocation.MyCommand.Name)`n$('-' * 80)"
     }
-
 }

--- a/source/stitch/BuildScripts/AddTaskFunctions/Resolve-TaskName.task.ps1
+++ b/source/stitch/BuildScripts/AddTaskFunctions/Resolve-TaskName.task.ps1
@@ -1,0 +1,36 @@
+
+function Resolve-TaskName {
+    <#
+    .SYNOPSIS
+        Get the task name from the given string.  A task name may be preceded by a '?'
+    #>
+    [CmdletBinding()]
+    param(
+        # The task name to check
+        [Parameter(
+            ValueFromPipeline
+        )]
+        [object]$Task
+    )
+    begin {
+        Write-Debug "`n$('-' * 80)`n-- Begin $($MyInvocation.MyCommand.Task)`n$('-' * 80)"
+    }
+    process {
+        if ($Task -is [string]) {
+            if ($Task[0] -eq '?') {
+                $Task.Substring(1) | Write-Output
+            } else {
+                $Task | Write-Output
+            }
+        }
+        elseif ($Task -is [scriptblock]) {
+            $Task | Write-Output
+        }
+        else {
+            throw "Invalid Task name $Task"
+        }
+    }
+    end {
+        Write-Debug "`n$('-' * 80)`n-- End $($MyInvocation.MyCommand.Task)`n$('-' * 80)"
+    }
+}

--- a/source/stitch/BuildScripts/AddTaskFunctions/Test-SafeTask.task.ps1
+++ b/source/stitch/BuildScripts/AddTaskFunctions/Test-SafeTask.task.ps1
@@ -1,0 +1,24 @@
+
+function Test-SafeTask {
+    <#
+    .SYNOPSIS
+        Return true if the task is a "Safe Task" (One that can have terminating errors without ending the build)
+    #>
+    [CmdletBinding()]
+    param(
+        # The name of the task
+        [Parameter(
+            ValueFromPipeline
+        )]
+        [string]$Name
+    )
+    begin {
+        Write-Debug "`n$('-' * 80)`n-- Begin $($MyInvocation.MyCommand.Name)`n$('-' * 80)"
+    }
+    process {
+        (if $Name.Substring(0,1) -eq '?') | Write-Output
+    }
+    end {
+        Write-Debug "`n$('-' * 80)`n-- End $($MyInvocation.MyCommand.Name)`n$('-' * 80)"
+    }
+}


### PR DESCRIPTION
This fix avoids the issue where Invoke-Build cannot add items to the `Jobs` array at runtime

Fixes #76

